### PR TITLE
relax dependencies

### DIFF
--- a/peggy.cabal
+++ b/peggy.cabal
@@ -45,10 +45,10 @@ Library
   
   Build-depends:       base             == 4.*
                      , mtl              >= 2.0
-                     , ListLike         == 3.1.*
-                     , hashtables       == 1.0.*
+                     , ListLike         >= 3.1 && < 4.2
+                     , hashtables       >= 1.0 && < 1.2
                      , monad-control    == 0.3.*
-                     , template-haskell >= 2.5 && < 2.9
+                     , template-haskell >= 2.5 && < 3.0
                      , haskell-src-meta >= 0.5
   
 Executable peggy-example


### PR DESCRIPTION
I relaxed version restriction of the following packages.

| package name | before | after | newest version (2014.04.19) |
| --- | --- | --- | --- |
| ListLike | == 3.1.* | >= 3.1 && < 4.1 | 4.0.2 |
| hashtables | == 1.0.* | >= 1.0 && < 1.2 | 1.1.2.1 |
| template-haskell | >= 2.5 && < 2.9 | >= 2.5 && < 3.0 | 2.9.0.0 |

build is success and there is no warning. (ghc-7.8.2)
