### PR TITLE
Remove upper bounds

### DIFF
--- a/peggy.cabal
+++ b/peggy.cabal
@@ -45,10 +45,10 @@ Library
   
   Build-depends:       base             == 4.*
                      , mtl              >= 2.0
-                     , ListLike         == 3.1.*
-                     , hashtables       == 1.0.*
-                     , monad-control    == 0.3.*
-                     , template-haskell >= 2.5 && < 2.9
+                     , ListLike         >= 3.1
+                     , hashtables       >= 1.0
+                     , monad-control    >= 0.3
+                     , template-haskell >= 2.5
                      , haskell-src-meta >= 0.5
   
 Executable peggy-example


### PR DESCRIPTION
Peggy compiles and works with the latest versions of its dependencies at the moment, so there's no reason to force upper bounds.
